### PR TITLE
Updated codemirror.js location (from src to lib) to fix code highlights

### DIFF
--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from 'svelte'
-  import CodeMirror from 'codemirror/src/codemirror.js'
+  import CodeMirror from 'codemirror/lib/codemirror.js'
 
   let classes = ''
 


### PR DESCRIPTION
import CodeMirror from 'codemirror/lib/codemirror.js'

seems the right location for codemirror.js